### PR TITLE
Hackerrank contest parser: handle no primary contest

### DIFF
--- a/src/parsers/contest/HackerRankContestParser.ts
+++ b/src/parsers/contest/HackerRankContestParser.ts
@@ -32,7 +32,9 @@ export class HackerRankContestParser extends Parser {
       );
 
       task.setName(model.name);
-      task.setCategory(model.primary_contest.name);
+      if(model.primary_contest) {
+        task.setCategory(model.primary_contest.name);
+      }
 
       new HackerRankProblemParser().parseTests(model.body_html, task);
 


### PR DESCRIPTION
Fix the exception if the primary contest is not set in Hackerrank's problem